### PR TITLE
Harden purge tenancy and remove global default account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ A Laravel application for managing multiple social media accounts and automated 
 - **PHPStan Analysis**: Level 5 static analysis with zero errors
 - **CI/CD Ready**: GitHub Actions workflow for automated testing and linting
 
+## Deployment Model & Tenancy
+
+This app is currently hardened for **single-tenant / internal allowlisted use**. It is not safe for external multi-user deployment until purges receive direct `user_id` ownership and all queries are tenant-scoped.
+
+Current isolation guarantees:
+
+- `PurgePolicy` only permits viewing a purge when it is bound to an account owned by the current user.
+- `PurgeService::processPurge()` never uses a global default account — an account is resolved from the purge itself or from an explicitly supplied user, otherwise the purge is skipped.
+- `PurgeService::getDefaultAccount(User $user)` is user-scoped; the previous `id = 1` hardcode is gone.
+- The CLI scheduler (`purge:process`) derives the acting user from `$purge->account->user` and skips unassigned purges.
+- CSV import auto-binds every imported purge to the importing user's active Twitter account.
+- Filament Purge queries (`PurgeResource::getEloquentQuery`, `PurgeBatchWidget`, stats action) are scoped to the current user's accounts.
+
+Before opening this app to external users, purges must gain a direct `user_id` column, a migration backfill, and every remaining bulk/CLI path must be refactored to respect that ownership.
+
 ## Tech Stack
 
 - **Laravel 12**: Latest framework features with modern PHP 8.2+

--- a/app/Console/Commands/ProcessPurgeQueue.php
+++ b/app/Console/Commands/ProcessPurgeQueue.php
@@ -23,12 +23,14 @@ class ProcessPurgeQueue extends Command
 
     /**
      * Execute the console command.
+     *
+     * The scheduler derives the acting user from the purge's account.
+     * Unassigned purges are skipped — we never fall back to a global default.
      */
     public function handle(PurgeService $purgeService): int
     {
         $this->info('Checking for pending purge requests...');
 
-        // Get the next pending purge
         $purge = $purgeService->getNextPendingPurge();
 
         if (! $purge) {
@@ -37,10 +39,21 @@ class ProcessPurgeQueue extends Command
             return Command::SUCCESS;
         }
 
-        $this->info("Processing purge for tweet {$purge->post_id}...");
+        $user = $purge->account?->user;
 
-        // Process the purge
-        $success = $purgeService->processPurge($purge);
+        if (! $user) {
+            $this->warn(
+                "Skipping purge {$purge->id}: no owning user could be derived from its account."
+            );
+
+            // Treat as a no-op for this tick — another run will pick up a
+            // well-formed purge. Orphans require manual cleanup.
+            return Command::SUCCESS;
+        }
+
+        $this->info("Processing purge for tweet {$purge->post_id} (user #{$user->id})...");
+
+        $success = $purgeService->processPurge($purge, $user);
 
         if ($success) {
             $this->info("✓ Successfully processed purge for tweet {$purge->post_id}");

--- a/app/Filament/Resources/Purges/Pages/ListPurges.php
+++ b/app/Filament/Resources/Purges/Pages/ListPurges.php
@@ -4,10 +4,12 @@ namespace App\Filament\Resources\Purges\Pages;
 
 use App\Filament\Resources\Purges\PurgeResource;
 use App\Models\Purge;
+use App\Services\PurgeService;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
 class ListPurges extends ListRecords
@@ -31,6 +33,23 @@ class ListPurges extends ListRecords
                         ->helperText('Upload a CSV file with columns: post_id, posted_at, text'),
                 ])
                 ->action(function (array $data) {
+                    /** @var \App\Models\User $user */
+                    $user = Auth::user();
+
+                    // Every imported purge must be bound to the importing
+                    // user's default active account. No orphan purges.
+                    $defaultAccount = app(PurgeService::class)->getDefaultAccount($user);
+
+                    if (! $defaultAccount) {
+                        Notification::make()
+                            ->danger()
+                            ->title('No active Twitter account')
+                            ->body('Connect an active Twitter account before importing tweets.')
+                            ->send();
+
+                        return;
+                    }
+
                     $filePath = Storage::disk('local')->path($data['csv_file']);
 
                     if (! file_exists($filePath)) {
@@ -145,6 +164,7 @@ class ListPurges extends ListRecords
                                 'posted_at' => ! empty($rowDataLower['posted_at']) ? $rowDataLower['posted_at'] : null,
                                 'text' => $rowDataLower['text'] ?? null,
                                 'save' => false,
+                                'account_id' => $defaultAccount->id,
                             ]);
 
                             $imported++;

--- a/app/Filament/Resources/Purges/Pages/ViewPurge.php
+++ b/app/Filament/Resources/Purges/Pages/ViewPurge.php
@@ -8,6 +8,7 @@ use App\Services\PurgeService;
 use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * @property Purge $record
@@ -50,7 +51,17 @@ class ViewPurge extends ViewRecord
                     // Refresh the record to get latest state
                     $this->record->refresh();
 
-                    $account = $this->record->account ?? $purgeService->getDefaultAccount();
+                    /** @var \App\Models\User $user */
+                    $user = Auth::user();
+
+                    // Block acting on a purge bound to someone else's account.
+                    if ($this->record->account && $this->record->account->user_id !== $user->id) {
+                        throw new \RuntimeException(
+                            'This purge is bound to an account you do not own.'
+                        );
+                    }
+
+                    $account = $this->record->account ?? $purgeService->getDefaultAccount($user);
 
                     if (! $account) {
                         throw new \RuntimeException(
@@ -60,7 +71,7 @@ class ViewPurge extends ViewRecord
                         );
                     }
 
-                    $success = $purgeService->processPurge($this->record);
+                    $success = $purgeService->processPurge($this->record, $user);
 
                     if ($success) {
                         Notification::make()

--- a/app/Filament/Resources/Purges/PurgeResource.php
+++ b/app/Filament/Resources/Purges/PurgeResource.php
@@ -11,6 +11,8 @@ use BackedEnum;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class PurgeResource extends Resource
 {
@@ -47,5 +49,21 @@ class PurgeResource extends Resource
             'index' => ListPurges::route('/'),
             'view' => ViewPurge::route('/{record}'),
         ];
+    }
+
+    /**
+     * Scope every Filament query to purges owned by the current user's
+     * accounts. Unassigned purges are hidden from the UI entirely.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+        $userId = Auth::id();
+
+        if ($userId === null) {
+            return $query->whereRaw('0 = 1');
+        }
+
+        return $query->whereHas('account', fn (Builder $q) => $q->where('user_id', $userId));
     }
 }

--- a/app/Filament/Resources/Purges/Tables/PurgesTable.php
+++ b/app/Filament/Resources/Purges/Tables/PurgesTable.php
@@ -9,6 +9,7 @@ use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class PurgesTable
 {
@@ -108,7 +109,11 @@ class PurgesTable
                     ->falseLabel('Not saved'),
 
                 Tables\Filters\SelectFilter::make('account_id')
-                    ->relationship('account', 'username')
+                    ->relationship(
+                        'account',
+                        'username',
+                        fn (Builder $query) => $query->where('user_id', Auth::id())
+                    )
                     ->label('Account'),
             ])
             ->recordActions([
@@ -137,7 +142,10 @@ class PurgesTable
                     ->icon('heroicon-o-chart-bar')
                     ->color('info')
                     ->action(function () {
-                        $stats = app(PurgeService::class)->getStats();
+                        /** @var \App\Models\User $user */
+                        $user = Auth::user();
+                        // UI callers must scope stats; never display global counts.
+                        $stats = app(PurgeService::class)->getStats($user);
 
                         Notification::make()
                             ->info()

--- a/app/Filament/Widgets/PurgeBatchWidget.php
+++ b/app/Filament/Widgets/PurgeBatchWidget.php
@@ -5,6 +5,8 @@ namespace App\Filament\Widgets;
 use App\Models\Purge;
 use Filament\Notifications\Notification;
 use Filament\Widgets\Widget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class PurgeBatchWidget extends Widget
 {
@@ -20,13 +22,29 @@ class PurgeBatchWidget extends Widget
 
     public bool $useRegex = false;
 
+    /**
+     * Build a base Purge query scoped to the current user's accounts.
+     * All batch operations are tenant-scoped; no global queries leak here.
+     *
+     * @return Builder<Purge>
+     */
+    protected function scopedQuery(): Builder
+    {
+        $userId = Auth::id();
+
+        return Purge::query()->whereHas(
+            'account',
+            fn (Builder $q) => $q->where('user_id', $userId)
+        );
+    }
+
     public function getSearchCount(): int
     {
         if (empty($this->searchText)) {
             return 0;
         }
 
-        $query = Purge::where('save', $this->operation === 'save' ? false : true);
+        $query = $this->scopedQuery()->where('save', $this->operation === 'save' ? false : true);
 
         if ($this->useRegex) {
             $purges = $query->get()->filter(function ($purge) {
@@ -70,7 +88,7 @@ class PurgeBatchWidget extends Widget
         $targetSaveState = $operation === 'save' ? false : true;
         $newSaveState = $operation === 'save' ? true : false;
 
-        $query = Purge::where('save', $targetSaveState);
+        $query = $this->scopedQuery()->where('save', $targetSaveState);
 
         if ($this->useRegex) {
             $purges = $query->get()->filter(function ($purge) {

--- a/app/Policies/PurgePolicy.php
+++ b/app/Policies/PurgePolicy.php
@@ -2,29 +2,40 @@
 
 namespace App\Policies;
 
+use App\Enums\AllowedEmailDomain;
 use App\Models\Purge;
 use App\Models\User;
 
+/**
+ * Single-tenant internal hardening policy.
+ *
+ * All decisions go through the purge's owning account. A purge whose
+ * account_id is null is treated as orphaned and invisible to everyone
+ * (see README — this app is not yet multi-tenant-safe).
+ */
 class PurgePolicy
 {
     /**
-     * Determine whether the user can view any models.
+     * List access: whitelisted users who have at least one connected account.
      */
     public function viewAny(User $user): bool
     {
-        return true;
+        return AllowedEmailDomain::isAllowed($user->email)
+            && $user->accounts()->exists();
     }
 
     /**
-     * Determine whether the user can view the model.
+     * A user can view a purge only if it is bound to one of their accounts.
+     * Unassigned purges are blocked.
      */
     public function view(User $user, Purge $purge): bool
     {
-        return true;
+        return $purge->account !== null
+            && $purge->account->user_id === $user->id;
     }
 
     /**
-     * Determine whether the user can create models.
+     * Purges are created via server-side CSV import, never via Filament form.
      */
     public function create(User $user): bool
     {
@@ -32,32 +43,24 @@ class PurgePolicy
     }
 
     /**
-     * Determine whether the user can update the model.
+     * Updates happen through narrow, explicit record actions (toggle save,
+     * manual purge) that carry their own auth checks. No generic edits.
      */
     public function update(User $user, Purge $purge): bool
     {
         return false;
     }
 
-    /**
-     * Determine whether the user can delete the model.
-     */
     public function delete(User $user, Purge $purge): bool
     {
         return false;
     }
 
-    /**
-     * Determine whether the user can restore the model.
-     */
     public function restore(User $user, Purge $purge): bool
     {
         return false;
     }
 
-    /**
-     * Determine whether the user can permanently delete the model.
-     */
     public function forceDelete(User $user, Purge $purge): bool
     {
         return false;

--- a/app/Services/PurgeService.php
+++ b/app/Services/PurgeService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Enums\SocialService;
 use App\Models\Account;
 use App\Models\Purge;
+use App\Models\User;
 use Illuminate\Support\Facades\Log;
 
 class PurgeService
@@ -14,56 +15,63 @@ class PurgeService
     ) {}
 
     /**
-     * Get the default Twitter account for purging.
-     * Returns the first connected Twitter account (ID = 1).
+     * Return the given user's first active Twitter account, or null.
+     *
+     * There is no global "account id = 1" default. A user context is
+     * required so we can never accidentally act on another tenant's account.
      */
-    public function getDefaultAccount(): ?Account
+    public function getDefaultAccount(User $user): ?Account
     {
-        return Account::where('service', SocialService::TWITTER)
-            ->where('id', 1)
+        return $user->accounts()
+            ->where('service', SocialService::TWITTER)
             ->where('is_active', true)
+            ->orderBy('id')
             ->first();
     }
 
     /**
-     * Process a single purge request.
+     * Process a single purge.
+     *
+     * Account resolution order:
+     *   1. $purge->account — used as-is. If $user is provided, the account
+     *      must belong to that user or the purge is skipped.
+     *   2. $user's default Twitter account — ONLY when $user is explicitly
+     *      provided by the caller (UI action or CLI with derived user).
+     *   3. Otherwise: skip and log. A global default is never used.
      */
-    public function processPurge(Purge $purge): bool
+    public function processPurge(Purge $purge, ?User $user = null): bool
     {
-        // Don't process if already requested or purged
         if ($purge->requested_at || $purge->purged_at) {
             Log::warning('Purge already processed', ['purge_id' => $purge->id]);
 
             return false;
         }
 
-        // Don't process if marked as saved
         if ($purge->save) {
             Log::info('Purge skipped - marked as saved', ['purge_id' => $purge->id]);
 
             return false;
         }
 
-        // Get the account to use
-        $account = $purge->account ?? $this->getDefaultAccount();
+        $account = $this->resolveAccount($purge, $user);
 
         if (! $account) {
-            Log::error('No Twitter account available for purge', ['purge_id' => $purge->id]);
+            Log::warning('Purge skipped - no account resolvable', [
+                'purge_id' => $purge->id,
+                'purge_has_account' => $purge->account_id !== null,
+                'user_provided' => $user !== null,
+            ]);
 
             return false;
         }
 
-        /** @var Account $account */
-
-        // Mark as requested before attempting
+        // Mark as requested before attempting (at-most-once semantics).
         $purge->update(['requested_at' => now()]);
 
         try {
-            // Attempt to delete the tweet
             $deleted = $this->twitterService->deleteTweet($purge, $account);
 
             if ($deleted) {
-                // Mark as purged
                 $purge->update(['purged_at' => now()]);
 
                 Log::info('Tweet purged successfully', [
@@ -92,30 +100,71 @@ class PurgeService
         }
     }
 
+    protected function resolveAccount(Purge $purge, ?User $user): ?Account
+    {
+        if ($purge->account) {
+            if ($user !== null && $purge->account->user_id !== $user->id) {
+                Log::warning('Purge account does not belong to provided user', [
+                    'purge_id' => $purge->id,
+                    'account_user_id' => $purge->account->user_id,
+                    'provided_user_id' => $user->id,
+                ]);
+
+                return null;
+            }
+
+            return $purge->account;
+        }
+
+        // Purge is unassigned. Only use the user's default when a user was
+        // explicitly supplied — never a silent global fallback.
+        if ($user === null) {
+            return null;
+        }
+
+        return $this->getDefaultAccount($user);
+    }
+
     /**
-     * Get the next pending purge to process.
-     * Returns the oldest tweet (by posted_at) that needs to be deleted.
+     * Next pending purge that has an assigned account (so a user is
+     * derivable). Unassigned purges are intentionally invisible to the
+     * scheduler.
      */
     public function getNextPendingPurge(): ?Purge
     {
         return Purge::pending()
+            ->whereNotNull('account_id')
             ->orderBy('posted_at', 'asc')
             ->first();
     }
 
     /**
-     * Get statistics about purge progress.
+     * Purge statistics.
+     *
+     * Pass $user (or $account) for tenant-scoped stats. UI code MUST pass
+     * one of these — global counts must never be shown on user-facing
+     * screens. Calling with neither returns global counts and is reserved
+     * for internal/CLI use.
      *
      * @return array{total: int, pending: int, requested: int, purged: int, saved: int}
      */
-    public function getStats(): array
+    public function getStats(?User $user = null, ?Account $account = null): array
     {
+        $base = Purge::query();
+
+        if ($account !== null) {
+            $base->where('account_id', $account->id);
+        } elseif ($user !== null) {
+            $userAccountIds = $user->accounts()->pluck('id');
+            $base->whereIn('account_id', $userAccountIds);
+        }
+
         return [
-            'total' => Purge::count(),
-            'pending' => Purge::pending()->count(),
-            'requested' => Purge::requested()->count(),
-            'purged' => Purge::purged()->count(),
-            'saved' => Purge::where('save', true)->count(),
+            'total' => (clone $base)->count(),
+            'pending' => (clone $base)->where('save', false)->whereNull('requested_at')->count(),
+            'requested' => (clone $base)->whereNotNull('requested_at')->whereNull('purged_at')->count(),
+            'purged' => (clone $base)->whereNotNull('purged_at')->count(),
+            'saved' => (clone $base)->where('save', true)->count(),
         ];
     }
 }

--- a/database/factories/PurgeFactory.php
+++ b/database/factories/PurgeFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Account;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -12,6 +13,10 @@ class PurgeFactory extends Factory
     /**
      * Define the model's default state.
      *
+     * By default a purge is bound to a freshly created Twitter account
+     * (owned by a freshly created user). Tests that need an orphan purge
+     * must set 'account_id' => null explicitly.
+     *
      * @return array<string, mixed>
      */
     public function definition(): array
@@ -20,6 +25,18 @@ class PurgeFactory extends Factory
             'post_id' => fake()->unique()->numberBetween(1, 1000000),
             'posted_at' => fake()->dateTimeBetween('-2 years', 'now'),
             'text' => fake()->optional(0.9)->sentence(20),
+            'account_id' => Account::factory()->twitter(),
         ];
+    }
+
+    /**
+     * An orphan purge with no owning account. The scheduler and UI must
+     * treat these as invisible under the single-tenant hardening.
+     */
+    public function orphan(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'account_id' => null,
+        ]);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "social",
+    "name": "project",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/tests/Feature/PurgeSecurityTest.php
+++ b/tests/Feature/PurgeSecurityTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Models\Account;
+use App\Models\Purge;
+use App\Models\User;
+use App\Services\PurgeService;
+use App\Services\TwitterAccountService;
+use Illuminate\Support\Facades\Artisan;
+
+/*
+|--------------------------------------------------------------------------
+| Single-tenant internal hardening — security regressions
+|--------------------------------------------------------------------------
+|
+| These tests cover the four explicit guarantees of the Option-A pass:
+|   1. A user cannot view another user's purge (policy-level).
+|   2. The scheduler does not process an unassigned purge by falling back
+|      to a global/default account.
+|   3. No purge path falls back to "account id = 1".
+|   4. User-facing stats are user-scoped (not global).
+|
+| These tests should not be relaxed without an equivalent multi-tenant
+| design (see README — Deployment Model & Tenancy).
+*/
+
+describe('PurgePolicy — cross-tenant isolation', function () {
+    it('user A cannot view user B\'s purge', function () {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $accountB = Account::factory()->for($userB)->twitter()->create();
+
+        $purgeB = Purge::factory()->create([
+            'account_id' => $accountB->id,
+        ]);
+
+        expect($userA->can('view', $purgeB))->toBeFalse();
+        expect($userB->can('view', $purgeB))->toBeTrue();
+    });
+
+    it('blocks viewing an unassigned (orphan) purge for every user', function () {
+        $userA = User::factory()->create();
+        Account::factory()->for($userA)->twitter()->create();
+
+        $orphan = Purge::factory()->orphan()->create();
+
+        expect($userA->can('view', $orphan))->toBeFalse();
+    });
+
+    it('viewAny requires whitelisted email AND at least one connected account', function () {
+        $whitelisted = User::factory()->create(['email' => 'someone@drewroberts.com']);
+        $outside = User::factory()->create(['email' => 'someone@example.com']);
+
+        // No accounts yet — both denied.
+        expect($whitelisted->can('viewAny', Purge::class))->toBeFalse();
+        expect($outside->can('viewAny', Purge::class))->toBeFalse();
+
+        Account::factory()->for($whitelisted)->twitter()->create();
+        Account::factory()->for($outside)->twitter()->create();
+
+        expect($whitelisted->fresh()->can('viewAny', Purge::class))->toBeTrue();
+        expect($outside->fresh()->can('viewAny', Purge::class))->toBeFalse();
+    });
+});
+
+describe('Scheduler — no global default fallback', function () {
+    it('skips an unassigned purge even when an active default-looking account exists', function () {
+        // Create an account that, under the old behavior, would have been
+        // treated as the id=1 default.
+        $strangerAccount = Account::factory()->twitter()->create([
+            'is_active' => true,
+            'username' => 'drewroberts',
+        ]);
+
+        expect($strangerAccount->id)->toBe(1);
+
+        $orphan = Purge::factory()->orphan()->create([
+            'save' => false,
+            'requested_at' => null,
+            'posted_at' => now()->subYears(2),
+        ]);
+
+        $this->mock(TwitterAccountService::class)
+            ->shouldNotReceive('deleteTweet');
+
+        $exit = Artisan::call('purge:process');
+
+        expect($exit)->toBe(0)
+            ->and($orphan->fresh())
+            ->requested_at->toBeNull()
+            ->purged_at->toBeNull();
+    });
+
+    it('prefers an assigned purge over any orphan on the queue', function () {
+        // Dangling orphan that predates everything — must NOT be picked.
+        Purge::factory()->orphan()->create([
+            'save' => false,
+            'requested_at' => null,
+            'posted_at' => now()->subYears(5),
+        ]);
+
+        $assigned = Purge::factory()->create([
+            'save' => false,
+            'requested_at' => null,
+            'posted_at' => now()->subDays(3),
+        ]);
+
+        $this->mock(TwitterAccountService::class)
+            ->shouldReceive('deleteTweet')
+            ->once()
+            ->andReturn(true);
+
+        Artisan::call('purge:process');
+
+        expect($assigned->fresh()->purged_at)->not->toBeNull();
+    });
+});
+
+describe('PurgeService — no account id = 1 fallback anywhere', function () {
+    it('getDefaultAccount never returns a stranger\'s account even when its id is 1', function () {
+        $stranger = Account::factory()->twitter()->create(['is_active' => true]);
+        expect($stranger->id)->toBe(1);
+
+        $user = User::factory()->create();
+
+        expect(app(PurgeService::class)->getDefaultAccount($user))->toBeNull();
+    });
+
+    it('processPurge does not resolve to a stranger\'s id=1 account for an orphan purge', function () {
+        $stranger = Account::factory()->twitter()->create(['is_active' => true]);
+        expect($stranger->id)->toBe(1);
+
+        $user = User::factory()->create();
+        // The user has no accounts — so even with an orphan purge and the
+        // id=1 stranger account present, resolution must fail.
+
+        $purge = Purge::factory()->orphan()->create([
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        $twitter = Mockery::mock(TwitterAccountService::class);
+        $twitter->shouldNotReceive('deleteTweet');
+
+        $service = new PurgeService($twitter);
+
+        expect($service->processPurge($purge, $user))->toBeFalse()
+            ->and($purge->fresh()->requested_at)->toBeNull();
+    });
+});
+
+describe('Stats — never global in user-facing contexts', function () {
+    it('getStats scoped to a user excludes another user\'s purges', function () {
+        $userA = User::factory()->create();
+        $accountA = Account::factory()->for($userA)->twitter()->create();
+
+        $userB = User::factory()->create();
+        $accountB = Account::factory()->for($userB)->twitter()->create();
+
+        Purge::factory()->count(3)->create([
+            'account_id' => $accountA->id,
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        Purge::factory()->count(7)->create([
+            'account_id' => $accountB->id,
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        $statsA = app(PurgeService::class)->getStats($userA);
+        $statsB = app(PurgeService::class)->getStats($userB);
+
+        expect($statsA['total'])->toBe(3)
+            ->and($statsB['total'])->toBe(7);
+    });
+
+    it('PurgesTable stats action uses a user-scoped call, not a global one', function () {
+        // Static inspection: the UI table MUST invoke getStats with a User.
+        $source = file_get_contents(
+            app_path('Filament/Resources/Purges/Tables/PurgesTable.php')
+        );
+
+        expect($source)
+            ->toContain('getStats($user)')
+            ->not->toMatch('/getStats\(\s*\)/');
+    });
+});

--- a/tests/Feature/PurgeTest.php
+++ b/tests/Feature/PurgeTest.php
@@ -341,26 +341,27 @@ describe('Account Integration', function () {
             ->and($purge2->account->username)->toBe('other');
     });
 
-    it('falls back to default account when purge has no account', function () {
-        $defaultAccount = Account::factory()->create([
+    it('scheduler does NOT process an unassigned purge, even when a default account exists', function () {
+        // A connected account that, under the old global-default behavior,
+        // would have been picked as the fallback.
+        Account::factory()->create([
             'service' => SocialService::TWITTER,
             'username' => 'drewroberts',
             'is_active' => true,
         ]);
 
-        $purge = Purge::factory()->create([
-            'account_id' => null,
+        $orphan = Purge::factory()->orphan()->create([
             'save' => false,
             'requested_at' => null,
         ]);
 
         $this->mock(TwitterAccountService::class)
-            ->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(true);
+            ->shouldNotReceive('deleteTweet');
 
         Artisan::call('purge:process');
 
-        expect($purge->fresh()->purged_at)->not->toBeNull();
+        expect($orphan->fresh())
+            ->requested_at->toBeNull()
+            ->purged_at->toBeNull();
     });
 });

--- a/tests/Unit/Services/PurgeServiceTest.php
+++ b/tests/Unit/Services/PurgeServiceTest.php
@@ -1,78 +1,84 @@
 <?php
 
-use App\Enums\SocialService;
 use App\Models\Account;
 use App\Models\Purge;
+use App\Models\User;
 use App\Services\PurgeService;
 use App\Services\TwitterAccountService;
 use Illuminate\Support\Facades\Log;
 
 describe('PurgeService - Default Account', function () {
-    it('finds default account by username', function () {
-        $defaultAccount = Account::factory()->create([
-            'service' => SocialService::TWITTER,
-            'username' => 'drewroberts',
+    it('returns the user\'s first active Twitter account', function () {
+        $user = User::factory()->create();
+
+        $expected = Account::factory()->for($user)->twitter()->create([
             'is_active' => true,
         ]);
 
-        $otherAccount = Account::factory()->create([
-            'service' => SocialService::TWITTER,
-            'username' => 'other',
+        Account::factory()->for($user)->twitter()->create([
             'is_active' => true,
         ]);
 
         $service = app(PurgeService::class);
-        $found = $service->getDefaultAccount();
 
-        expect($found)
+        expect($service->getDefaultAccount($user))
             ->toBeInstanceOf(Account::class)
-            ->id->toBe($defaultAccount->id);
+            ->id->toBe($expected->id);
     });
 
-    it('returns null when default account does not exist', function () {
-        // Create an account with ID=2 (not the default ID=1)
-        Account::factory()->create([
-            'id' => 2,
-            'service' => SocialService::TWITTER,
-            'username' => 'other',
-            'is_active' => true,
-        ]);
+    it('returns null when the user has no connected accounts', function () {
+        $user = User::factory()->create();
 
         $service = app(PurgeService::class);
-        $found = $service->getDefaultAccount();
 
-        expect($found)->toBeNull();
+        expect($service->getDefaultAccount($user))->toBeNull();
     });
 
-    it('only finds active accounts', function () {
-        Account::factory()->create([
-            'service' => SocialService::TWITTER,
-            'username' => 'drewroberts',
+    it('ignores inactive Twitter accounts', function () {
+        $user = User::factory()->create();
+
+        Account::factory()->for($user)->twitter()->create([
             'is_active' => false,
         ]);
 
         $service = app(PurgeService::class);
-        $found = $service->getDefaultAccount();
 
-        expect($found)->toBeNull();
+        expect($service->getDefaultAccount($user))->toBeNull();
     });
 
-    it('only finds Twitter accounts', function () {
-        Account::factory()->create([
-            'service' => SocialService::FACEBOOK,
-            'username' => 'drewroberts',
+    it('ignores non-Twitter accounts', function () {
+        $user = User::factory()->create();
+
+        Account::factory()->for($user)->facebook()->create([
             'is_active' => true,
         ]);
 
         $service = app(PurgeService::class);
-        $found = $service->getDefaultAccount();
 
-        expect($found)->toBeNull();
+        expect($service->getDefaultAccount($user))->toBeNull();
+    });
+
+    it('never falls back to a global account id = 1', function () {
+        // A "legacy" account owned by someone else that previously would have
+        // been returned by the old hardcoded lookup.
+        $strangerAccount = Account::factory()->twitter()->create([
+            'is_active' => true,
+        ]);
+        // Force the stranger's account to id = 1 to mirror the old default.
+        // (First created account in a fresh DB already gets id = 1, but we
+        // assert explicitly.)
+        expect($strangerAccount->id)->toBe(1);
+
+        $user = User::factory()->create();
+
+        $service = app(PurgeService::class);
+
+        expect($service->getDefaultAccount($user))->toBeNull();
     });
 });
 
 describe('PurgeService - Next Pending Purge', function () {
-    it('returns oldest pending purge', function () {
+    it('returns oldest pending purge with an assigned account', function () {
         $oldest = Purge::factory()->create([
             'posted_at' => now()->subDays(10),
             'save' => false,
@@ -85,25 +91,13 @@ describe('PurgeService - Next Pending Purge', function () {
             'requested_at' => null,
         ]);
 
-        Purge::factory()->create([
-            'posted_at' => now()->subDays(1),
-            'save' => false,
-            'requested_at' => null,
-        ]);
-
-        $service = app(PurgeService::class);
-        $next = $service->getNextPendingPurge();
-
-        expect($next)
-            ->toBeInstanceOf(Purge::class)
-            ->id->toBe($oldest->id);
+        expect(app(PurgeService::class)->getNextPendingPurge()->id)->toBe($oldest->id);
     });
 
     it('excludes saved purges', function () {
         Purge::factory()->create([
             'posted_at' => now()->subDays(10),
             'save' => true,
-            'requested_at' => null,
         ]);
 
         $expected = Purge::factory()->create([
@@ -112,10 +106,7 @@ describe('PurgeService - Next Pending Purge', function () {
             'requested_at' => null,
         ]);
 
-        $service = app(PurgeService::class);
-        $next = $service->getNextPendingPurge();
-
-        expect($next->id)->toBe($expected->id);
+        expect(app(PurgeService::class)->getNextPendingPurge()->id)->toBe($expected->id);
     });
 
     it('excludes already requested purges', function () {
@@ -131,13 +122,26 @@ describe('PurgeService - Next Pending Purge', function () {
             'requested_at' => null,
         ]);
 
-        $service = app(PurgeService::class);
-        $next = $service->getNextPendingPurge();
-
-        expect($next->id)->toBe($expected->id);
+        expect(app(PurgeService::class)->getNextPendingPurge()->id)->toBe($expected->id);
     });
 
-    it('returns null when no pending purges exist', function () {
+    it('excludes unassigned purges (no account)', function () {
+        Purge::factory()->orphan()->create([
+            'posted_at' => now()->subDays(30),
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        $assigned = Purge::factory()->create([
+            'posted_at' => now()->subDays(5),
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        expect(app(PurgeService::class)->getNextPendingPurge()->id)->toBe($assigned->id);
+    });
+
+    it('returns null when nothing is eligible', function () {
         Purge::factory()->create([
             'save' => true,
             'requested_at' => null,
@@ -148,117 +152,114 @@ describe('PurgeService - Next Pending Purge', function () {
             'requested_at' => now(),
         ]);
 
-        $service = app(PurgeService::class);
-        $next = $service->getNextPendingPurge();
-
-        expect($next)->toBeNull();
+        expect(app(PurgeService::class)->getNextPendingPurge())->toBeNull();
     });
 });
 
 describe('PurgeService - Statistics', function () {
     beforeEach(function () {
+        $this->user = User::factory()->create();
+        $this->account = Account::factory()->for($this->user)->twitter()->create();
+
         Purge::factory()->count(3)->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         Purge::factory()->count(2)->create([
+            'account_id' => $this->account->id,
             'save' => true,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         Purge::factory()->count(4)->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => now()->subHour(),
             'purged_at' => null,
         ]);
 
         Purge::factory()->count(5)->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => now()->subDay(),
             'purged_at' => now()->subHours(12),
         ]);
     });
 
-    it('returns correct total count', function () {
-        $service = app(PurgeService::class);
-        $stats = $service->getStats();
+    it('scopes stats to the supplied user', function () {
+        $stats = app(PurgeService::class)->getStats($this->user);
+
+        expect($stats)->toMatchArray([
+            'total' => 14,
+            'pending' => 3,
+            'saved' => 2,
+            'requested' => 4,
+            'purged' => 5,
+        ]);
+    });
+
+    it('scopes stats to a specific account', function () {
+        $stats = app(PurgeService::class)->getStats(null, $this->account);
 
         expect($stats['total'])->toBe(14);
     });
 
-    it('returns correct pending count', function () {
-        $service = app(PurgeService::class);
-        $stats = $service->getStats();
+    it('excludes purges owned by other users when scoped', function () {
+        $otherUser = User::factory()->create();
+        $otherAccount = Account::factory()->for($otherUser)->twitter()->create();
 
-        expect($stats['pending'])->toBe(3);
-    });
+        Purge::factory()->count(7)->create([
+            'account_id' => $otherAccount->id,
+            'save' => false,
+            'requested_at' => null,
+        ]);
 
-    it('returns correct saved count', function () {
-        $service = app(PurgeService::class);
-        $stats = $service->getStats();
+        $stats = app(PurgeService::class)->getStats($this->user);
 
-        expect($stats['saved'])->toBe(2);
-    });
-
-    it('returns correct requested count', function () {
-        $service = app(PurgeService::class);
-        $stats = $service->getStats();
-
-        expect($stats['requested'])->toBe(4);
-    });
-
-    it('returns correct purged count', function () {
-        $service = app(PurgeService::class);
-        $stats = $service->getStats();
-
-        expect($stats['purged'])->toBe(5);
+        expect($stats['total'])->toBe(14);
     });
 });
 
 describe('PurgeService - Process Purge', function () {
     beforeEach(function () {
-        $this->account = Account::factory()->create([
-            'service' => SocialService::TWITTER,
-            'username' => 'drewroberts',
-            'is_active' => true,
-        ]);
+        $this->user = User::factory()->create();
+        $this->account = Account::factory()->for($this->user)->twitter()->create();
     });
 
     it('marks purge as requested before attempting deletion', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(true);
+        $twitterService->shouldReceive('deleteTweet')->once()->andReturn(true);
 
         $service = new PurgeService($twitterService);
-        $service->processPurge($purge);
+        $service->processPurge($purge, $this->user);
 
         expect($purge->fresh()->requested_at)->not->toBeNull();
     });
 
     it('marks purge as purged on successful deletion', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(true);
+        $twitterService->shouldReceive('deleteTweet')->once()->andReturn(true);
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
+        $result = $service->processPurge($purge, $this->user);
 
         expect($result)->toBeTrue()
             ->and($purge->fresh()->purged_at)->not->toBeNull();
@@ -266,6 +267,7 @@ describe('PurgeService - Process Purge', function () {
 
     it('returns false for already requested purge', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => now()->subHour(),
             'purged_at' => null,
@@ -277,13 +279,13 @@ describe('PurgeService - Process Purge', function () {
         Log::shouldReceive('warning')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse();
+        expect($service->processPurge($purge, $this->user))->toBeFalse();
     });
 
     it('returns false for already purged record', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => now()->subHour(),
             'purged_at' => now()->subMinutes(30),
@@ -295,13 +297,13 @@ describe('PurgeService - Process Purge', function () {
         Log::shouldReceive('warning')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse();
+        expect($service->processPurge($purge, $this->user))->toBeFalse();
     });
 
     it('skips saved purges', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => true,
             'requested_at' => null,
             'purged_at' => null,
@@ -313,113 +315,133 @@ describe('PurgeService - Process Purge', function () {
         Log::shouldReceive('info')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse()
+        expect($service->processPurge($purge, $this->user))->toBeFalse()
             ->and($purge->fresh()->requested_at)->toBeNull();
     });
 
-    it('uses purge account when available', function () {
-        $specificAccount = Account::factory()->create([
-            'service' => SocialService::TWITTER,
-            'is_active' => true,
-        ]);
-
+    it('uses the purge-bound account when present', function () {
         $purge = Purge::factory()->create([
-            'account_id' => $specificAccount->id,
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(true);
+        $twitterService->shouldReceive('deleteTweet')->once()->andReturn(true);
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeTrue();
+        expect($service->processPurge($purge, $this->user))->toBeTrue();
     });
 
-    it('uses default account when purge has no account', function () {
-        $purge = Purge::factory()->create([
-            'account_id' => null,
+    it('uses the user\'s default account when purge is unassigned AND user is provided', function () {
+        $purge = Purge::factory()->orphan()->create([
             'save' => false,
             'requested_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(true);
+        $twitterService->shouldReceive('deleteTweet')->once()->andReturn(true);
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeTrue();
+        expect($service->processPurge($purge, $this->user))->toBeTrue();
     });
 
-    it('returns false when no account available', function () {
-        $purge = Purge::factory()->create([
-            'account_id' => null,
+    it('skips when purge is unassigned AND no user is provided', function () {
+        $purge = Purge::factory()->orphan()->create([
             'save' => false,
             'requested_at' => null,
         ]);
-
-        // Delete the default account
-        $this->account->delete();
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
         $twitterService->shouldNotReceive('deleteTweet');
 
-        Log::shouldReceive('error')->once();
+        Log::shouldReceive('warning')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse()
-            ->and($purge->fresh()->requested_at)->toBeNull(); // Does not mark as requested when no account
+        expect($service->processPurge($purge))->toBeFalse()
+            ->and($purge->fresh()->requested_at)->toBeNull();
+    });
+
+    it('skips when the provided user does not own the purge\'s account', function () {
+        $otherUser = User::factory()->create();
+        $otherAccount = Account::factory()->for($otherUser)->twitter()->create();
+
+        $purge = Purge::factory()->create([
+            'account_id' => $otherAccount->id,
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        $twitterService = Mockery::mock(TwitterAccountService::class);
+        $twitterService->shouldNotReceive('deleteTweet');
+
+        // Two warnings: the ownership mismatch (specific) plus the
+        // "no account resolvable" catch-all that follows.
+        Log::shouldReceive('warning')->twice();
+
+        $service = new PurgeService($twitterService);
+
+        expect($service->processPurge($purge, $this->user))->toBeFalse()
+            ->and($purge->fresh()->requested_at)->toBeNull();
+    });
+
+    it('skips when purge is unassigned and the user has no accounts', function () {
+        $lonelyUser = User::factory()->create();
+
+        $purge = Purge::factory()->orphan()->create([
+            'save' => false,
+            'requested_at' => null,
+        ]);
+
+        $twitterService = Mockery::mock(TwitterAccountService::class);
+        $twitterService->shouldNotReceive('deleteTweet');
+
+        Log::shouldReceive('warning')->once();
+
+        $service = new PurgeService($twitterService);
+
+        expect($service->processPurge($purge, $lonelyUser))->toBeFalse()
+            ->and($purge->fresh()->requested_at)->toBeNull();
     });
 
     it('handles deletion failure gracefully', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andReturn(false);
+        $twitterService->shouldReceive('deleteTweet')->once()->andReturn(false);
 
         Log::shouldReceive('warning')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse()
+        expect($service->processPurge($purge, $this->user))->toBeFalse()
             ->and($purge->fresh()->purged_at)->toBeNull();
     });
 
     it('handles exceptions during deletion', function () {
         $purge = Purge::factory()->create([
+            'account_id' => $this->account->id,
             'save' => false,
             'requested_at' => null,
             'purged_at' => null,
         ]);
 
         $twitterService = Mockery::mock(TwitterAccountService::class);
-        $twitterService->shouldReceive('deleteTweet')
-            ->once()
-            ->andThrow(new Exception('API Error'));
+        $twitterService->shouldReceive('deleteTweet')->once()->andThrow(new Exception('API Error'));
 
         Log::shouldReceive('error')->once();
 
         $service = new PurgeService($twitterService);
-        $result = $service->processPurge($purge);
 
-        expect($result)->toBeFalse();
+        expect($service->processPurge($purge, $this->user))->toBeFalse();
     });
 });


### PR DESCRIPTION
## Summary

This PR hardens the tweet purge flow for internal/single-tenant use by removing global account fallback behavior and enforcing account ownership checks across policies, services, scheduler, Filament resources, widgets, CSV import, factories, and tests.

## Security changes

- Removes the hardcoded `account id = 1` fallback from purge processing.
- Requires purge processing to resolve ownership through the purge account or explicit user context.
- Skips orphaned/unassigned purges instead of processing them with a global default account.
- Scopes purge list views, stats, filters, batch widgets, and CSV imports to the authenticated user's accounts.
- Tightens `PurgePolicy` so users can only view purges owned by their accounts.
- Documents current deployment model as internal/single-tenant hardening, not external multi-tenant readiness.

## Validation

- `php artisan test`: 132 passed, 329 assertions
- `composer analyse`: 0 errors at PHPStan level 5
- `composer format`: clean after Pint fixes

## Notes

Real Twitter/X credentials remain blank and should not be connected until this PR is reviewed and merged. The app should still be treated as internal/allowlisted until a full `purges.user_id` multi-tenant migration is implemented.